### PR TITLE
feat: use tailwind palette colors

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${inter.className} bg-[#030014] overflow-y-scroll overflow-x-hidden`}
+        className={`${inter.className} bg-neutral overflow-y-scroll overflow-x-hidden`}
       >
         <div className="relative z-[30]">
           <Navbar />

--- a/components/main/Navbar.tsx
+++ b/components/main/Navbar.tsx
@@ -5,7 +5,7 @@ import React from "react";
 
 const Navbar = () => {
   return (
-    <div className="w-full h-[65px] fixed top-0 shadow-lg shadow-[#2A0E61]/50 bg-[#03001417] backdrop-blur-md z-50 px-10">
+    <div className="w-full h-[65px] fixed top-0 shadow-lg shadow-[#2A0E61]/50 bg-neutral backdrop-blur-md z-50 px-10">
       <div className="w-full h-full flex flex-row items-center justify-between m-auto px-[10px]">
         <a
           href="#about-me"
@@ -25,7 +25,7 @@ const Navbar = () => {
         </a>
 
         <div className="w-[500px] h-full flex flex-row items-center justify-between md:mr-20">
-          <div className="flex items-center justify-between w-full h-auto border border-[#7042f861] bg-[#0300145e] mr-[15px] px-[20px] py-[10px] rounded-full text-gray-200">
+          <div className="flex items-center justify-between w-full h-auto border border-[#7042f861] bg-neutral mr-[15px] px-[20px] py-[10px] rounded-full text-gray-200">
             <a href="#about-me" className="cursor-pointer">
               About me
             </a>

--- a/components/sub/HeroContent.tsx
+++ b/components/sub/HeroContent.tsx
@@ -23,7 +23,7 @@ const HeroContent = () => {
           variants={slideInFromTop}
           className="Welcome-box py-[8px] px-[7px] border border-[#7042f88b] opacity-[0.9] flex items-center"
         >
-          <SparklesIcon className="text-[#b49bff] mr-[10px] h-5 w-5" />
+          <SparklesIcon className="text-primary mr-[10px] h-5 w-5" />
           <h1 className="Welcome-text text-[13px]">IT Specialist &nbsp;</h1>
         </motion.div>
 

--- a/components/sub/SkillText.tsx
+++ b/components/sub/SkillText.tsx
@@ -17,7 +17,7 @@ const SkillText = () => {
       >
         <SparklesIcon
           data-testid="sparkles-icon"
-          className="text-[#b49bff] mr-[10px] h-5 w-5"
+          className="text-primary mr-[10px] h-5 w-5"
         />
         <h1 className="Welcome-text text-[13px]">Quick learner &nbsp;</h1>
       </motion.div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,6 +8,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      colors: {
+        primary: '#1D4ED8',
+        neutral: '#F3F4F6',
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':


### PR DESCRIPTION
## Summary
- add primary and neutral colors to Tailwind theme
- replace hex-based text and backgrounds with `text-primary` and `bg-neutral`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aca8ed3c0c832584e4971ca6f1d770