### PR TITLE
refactor: simplify CV section styling

### DIFF
--- a/components/sub/CVContent.tsx
+++ b/components/sub/CVContent.tsx
@@ -25,9 +25,7 @@ const CVContent = () => {
           viewport={{ once: true, amount: 0.2 }}
           className="py-[8px] px-[7px] opacity-[0.9] w-full"
         >
-          <h1 className="text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-purple-500 to-cyan-500">
-            Curriculum Vitae
-          </h1>
+          <h1 className="text-5xl font-bold text-gray-900">Curriculum Vitae</h1>
         </motion.div>
 
         {/* Introduction */}
@@ -48,11 +46,11 @@ const CVContent = () => {
           whileInView="visible"
           initial="hidden"
           viewport={{ once: true, amount: 0.2 }}
-          className="w-full p-8 bg-gray-800 bg-opacity-10 rounded-lg shadow-lg"
+          className="w-full p-8 bg-white border border-gray-200 rounded-lg shadow-lg"
         >
           {/* Expérience professionnelle */}
           <section className="mb-6 w-full">
-            <h2 className="text-2xl font-semibold mb-2 text-white">
+            <h2 className="text-2xl font-semibold mb-2 text-gray-900">
               Professional Experience
             </h2>
             <p className="text-lg text-gray-300 w-full">
@@ -71,7 +69,7 @@ const CVContent = () => {
 
           {/* Éducation */}
           <section className="mb-6 w-full">
-            <h2 className="text-2xl font-semibold mb-2 text-white">
+            <h2 className="text-2xl font-semibold mb-2 text-gray-900">
               Education
             </h2>
             <p className="text-lg text-gray-300 w-full">
@@ -86,7 +84,7 @@ const CVContent = () => {
 
           {/* Compétences */}
           <section className="mb-6 w-full">
-            <h2 className="text-2xl font-semibold mb-2 text-white">Skills</h2>
+            <h2 className="text-2xl font-semibold mb-2 text-gray-900">Skills</h2>
             <p className="text-lg text-gray-300 w-full">
               <strong>Technical Skills:</strong> C, C++, Java, Scala, Python,
               Flask, TailwindCSS, Next.js, ChromaDB, Scikit-learn, Docker,
@@ -101,7 +99,7 @@ const CVContent = () => {
 
           {/* À propos de moi */}
           <section className="mb-6 w-full">
-            <h2 className="text-2xl font-semibold mb-2 text-white">About Me</h2>
+            <h2 className="text-2xl font-semibold mb-2 text-gray-900">About Me</h2>
             <p className="text-lg text-gray-300 w-full">
               My transition from specialized education to IT has been a
               transformative journey. In addition to my work, I am a passionate
@@ -116,12 +114,12 @@ const CVContent = () => {
             whileInView="visible"
             initial="hidden"
             viewport={{ once: true, amount: 0.2 }}
-            className="py-2 button-primary text-center text-white cursor-pointer rounded-lg max-w-[200px] mx-auto"
+            className="py-2 text-center cursor-pointer max-w-[200px] mx-auto"
           >
             <Link
               href="/cv.pdf"
               download
-              className="text-white flex items-center justify-center gap-2"
+              className="border border-gray-300 bg-gray-100 hover:bg-gray-200 text-gray-800 flex items-center justify-center gap-2 px-4 py-2 rounded-lg"
             >
               <ArrowDownTrayIcon className="w-5 h-5" />
               My CV


### PR DESCRIPTION
## Summary
- use text-gray-900 for CV titles instead of gradients
- switch CV content background to white with a light border
- apply minimal Tailwind styling to the CV download button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca8e972e48325aa6e939e9f813bbe