### PR TITLE
refactor: simplify skill section

### DIFF
--- a/__tests__/SkillText.test.js
+++ b/__tests__/SkillText.test.js
@@ -9,21 +9,17 @@ describe("SkillText Component", () => {
     expect(container).toBeInTheDocument();
   });
 
-  it("displays the quick learner message with SparklesIcon", () => {
+  it("displays the Skills heading", () => {
     render(<SkillText />);
-
-    expect(screen.getByTestId("sparkles-icon")).toBeInTheDocument();
-  });
-  it("displays the central motivational text", () => {
-    render(<SkillText />);
-    const motivationalText = screen.getByText(
-      "Diving into the future, fueled by a love for exploring new tech.",
-    );
-    expect(motivationalText).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /skills/i })
+    ).toBeInTheDocument();
   });
 
-  it('renders the "My go-to skills" section', () => {
+  it("shows the descriptive paragraph", () => {
     render(<SkillText />);
-    expect(screen.getByText("My go-to skills")).toBeInTheDocument();
+    expect(
+      screen.getByText(/snapshot of the technologies/i)
+    ).toBeInTheDocument();
   });
 });

--- a/__tests__/Skills.test.js
+++ b/__tests__/Skills.test.js
@@ -45,7 +45,7 @@ jest.mock("@/constants", () => ({
 describe("Skills Component", () => {
   it("renders without crashing", () => {
     render(<Skills />);
-    expect(screen.getByText(/My go-to skills/i)).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: /skills/i })).toBeInTheDocument();
   });
 
   it("renders Skill_data images", () => {

--- a/components/sub/SkillDataProvider.tsx
+++ b/components/sub/SkillDataProvider.tsx
@@ -40,7 +40,7 @@ const SkillDataProvider = ({ src, width, height, alt, index }: Props) => {
         width={width}
         height={height}
         alt={alt}
-        className="object-contain"
+        className="object-contain transition-opacity hover:opacity-80"
       />
     </motion.div>
   );

--- a/components/sub/SkillText.tsx
+++ b/components/sub/SkillText.tsx
@@ -1,38 +1,13 @@
 "use client";
 import React from "react";
-import { motion } from "framer-motion";
-import {
-  slideInFromLeft,
-  slideInFromRight,
-  slideInFromTop,
-} from "@/lib/utils/motion";
-import { SparklesIcon } from "@heroicons/react/24/solid";
 
 const SkillText = () => {
   return (
     <div className="w-full h-auto flex flex-col items-center justify-center">
-      <motion.div
-        variants={slideInFromTop}
-        className="Welcome-box py-[8px] px-[7px] border border-[#7042f88b] opacity-[0.9]"
-      >
-        <SparklesIcon
-          data-testid="sparkles-icon"
-          className="text-[#b49bff] mr-[10px] h-5 w-5"
-        />
-        <h1 className="Welcome-text text-[13px]">Quick learner &nbsp;</h1>
-      </motion.div>
-      <motion.div
-        variants={slideInFromLeft(0.5)}
-        className="text-[30px] text-white font-medium mt-[10px] text-center mb-[15px]"
-      >
-        Diving into the future, fueled by a love for exploring new tech.
-      </motion.div>
-      <motion.div
-        variants={slideInFromRight(0.5)}
-        className="cursive text-[20px] text-gray-200 mb-10 mt-[10px] text-center"
-      >
-        My go-to skills
-      </motion.div>
+      <h2 className="text-3xl font-semibold text-gray-900 text-center">Skills</h2>
+      <p className="text-gray-600 text-center mt-4">
+        A snapshot of the technologies I work with.
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- simplify skills section with plain heading and description
- add basic opacity hover effect to skill icons
- update tests for new skills text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aca8e1d8d48325b93023b4d56130be