### PR TITLE
refactor: use tailwind scale classes for skills

### DIFF
--- a/components/main/Skills.tsx
+++ b/components/main/Skills.tsx
@@ -21,8 +21,7 @@ const Skills = () => {
   return (
     <section
       id="skills"
-      className="flex flex-col items-center justify-center gap-3 h-full relative overflow-hidden pb-20 py-10"
-      style={{ transform: "scale(0.9)" }}
+      className="flex flex-col items-center justify-center gap-3 h-full relative overflow-hidden pb-20 py-10 scale-90 md:scale-100"
     >
       <SkillText />
 


### PR DESCRIPTION
## Summary
- replace inline transform scale on Skills section with responsive Tailwind classes

## Testing
- `npm test` *(fails: ReferenceError: motion is not defined)*
- `npm run lint` *(fails: motion is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d3615308325ad5cd0ad0f86c094