### PR TITLE
fix: improve navbar responsiveness and contrast

### DIFF
--- a/components/main/Navbar.tsx
+++ b/components/main/Navbar.tsx
@@ -26,8 +26,8 @@ const Navbar = () => {
           </span>
         </a>
 
-        <div className="w-[500px] h-full flex flex-row items-center justify-between md:mr-20">
-          <div className="flex items-center justify-between w-full h-auto border border-[#7042f861] bg-neutral mr-[15px] px-[20px] py-[10px] rounded-full text-gray-200">
+        <div className="w-full md:max-w-[500px] h-full flex flex-row items-center justify-between md:mr-20">
+          <div className="flex items-center justify-between w-full h-auto border border-[#7042f861] bg-neutral mr-[15px] px-[20px] py-[10px] rounded-full text-gray-800">
             <a href="#about-me" className="cursor-pointer">
 
               About me


### PR DESCRIPTION
## Summary
- make navbar responsive by replacing fixed width with full width and max width on medium screens
- use darker text color for better contrast

## Testing
- `npm test` *(fails: motion is not defined in SkillText tests)*
- `npm run lint` *(fails: 'motion' and 'SparklesIcon' are not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5d37072083259fc95db7590e7383