### PR TITLE
feat: add keita noise wave background

### DIFF
--- a/components/portfolio-card/Container.tsx
+++ b/components/portfolio-card/Container.tsx
@@ -5,7 +5,7 @@ import { motion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
 import LanguageToggle from "./LanguageToggle";
 import SocialLinks from "./SocialLinks";
-import SubtleFilmGrain from "./SubtleFilmGrain";
+import KeitaNoiseBackground from "./KeitaNoiseBackground";
 
 interface ContainerProps {
   children: React.ReactNode;
@@ -22,7 +22,7 @@ const Container: React.FC<ContainerProps> = ({ children }) => {
           animate={{ opacity: 1 }}
           transition={{ duration: 1, ease: "easeInOut" }}
         >
-          <SubtleFilmGrain />
+          <KeitaNoiseBackground />
           <SocialLinks />
           {children}
         </motion.div>

--- a/components/portfolio-card/KeitaNoiseBackground.tsx
+++ b/components/portfolio-card/KeitaNoiseBackground.tsx
@@ -5,8 +5,18 @@ import React from 'react';
 const KeitaNoiseBackground: React.FC = () => {
   return (
     <div className="absolute inset-0 pointer-events-none z-0">
+      {/* Subtle moving noise waves */}
+      <div
+        className="absolute inset-0 opacity-[0.04]"
+        style={{
+          backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 400 400'%3E%3Cfilter id='waves'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.3' numOctaves='5' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23waves)' opacity='0.5'/%3E%3C/svg%3E")`,
+          backgroundSize: '400px 400px',
+          animation: 'wave-flow 25s linear infinite',
+          mixBlendMode: 'overlay',
+        }}
+      />
       {/* Fine film grain texture like Keita Yamada */}
-      <div 
+      <div
         className="absolute inset-0 opacity-[0.03]"
         style={{
           backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cfilter id='finegrain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='1' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23finegrain)' opacity='1'/%3E%3C/svg%3E")`,
@@ -16,7 +26,7 @@ const KeitaNoiseBackground: React.FC = () => {
       />
       
       {/* Secondary very fine noise */}
-      <div 
+      <div
         className="absolute inset-0 opacity-[0.02]"
         style={{
           backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 50 50'%3E%3Cfilter id='ultrafine'%3E%3CfeTurbulence type='turbulence' baseFrequency='2.0' numOctaves='1' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23ultrafine)' opacity='0.5'/%3E%3C/svg%3E")`,


### PR DESCRIPTION
## Summary
- add animated wave layer to Keita noise background for subtle motion
- use new noise background in main container

## Testing
- `npm test` *(fails: Could not locate module @/constants mapped as: /workspace/showcase/$1, and other missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68af683ccefc8325b976d7704072dcc7