### PR TITLE
Define ContainerSlideIn prop types

### DIFF
--- a/components/portfolio-card/About.tsx
+++ b/components/portfolio-card/About.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { motion } from "framer-motion";
+import type { HTMLMotionProps, Variants } from "framer-motion";
 import { useTranslation } from "./useTranslation";
 
 const fadeIn = (direction: string, type: string, delay: number, duration: number) => {
@@ -47,7 +48,12 @@ const staggerContainer = (staggerChildren?: number, delayChildren?: number) => (
   },
 });
 
-export const ContainerSlideIn = ({ children, variants, ...props }: any) => (
+interface ContainerSlideInProps extends HTMLMotionProps<"div"> {
+  children: React.ReactNode;
+  variants: Variants;
+}
+
+export const ContainerSlideIn = ({ children, variants, ...props }: ContainerSlideInProps) => (
   <motion.div {...props} variants={variants} className="relative">
     {children}
   </motion.div>


### PR DESCRIPTION
## Summary
- add explicit ContainerSlideInProps interface for portfolio card
- replace `any` in ContainerSlideIn with typed props

## Testing
- `npm run lint` *(fails: Unexpected any in DetailedAbout.tsx, Projects.tsx)*
- `npm run build` *(fails: failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68affcf125088325a16468eb3daf444f