### PR TITLE
chore: tighten typings for portfolio components

### DIFF
--- a/components/portfolio-card/About.tsx
+++ b/components/portfolio-card/About.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React from "react";
-import { motion } from "framer-motion";
+import {
+  motion,
+  type Variants,
+  type HTMLMotionProps,
+} from "framer-motion";
 import { useTranslation } from "./useTranslation";
 
 const fadeIn = (direction: string, type: string, delay: number, duration: number) => {
@@ -47,7 +51,16 @@ const staggerContainer = (staggerChildren?: number, delayChildren?: number) => (
   },
 });
 
-export const ContainerSlideIn = ({ children, variants, ...props }: any) => (
+interface ContainerSlideInProps extends HTMLMotionProps<"div"> {
+  children: React.ReactNode;
+  variants?: Variants;
+}
+
+export const ContainerSlideIn = ({
+  children,
+  variants,
+  ...props
+}: ContainerSlideInProps) => (
   <motion.div {...props} variants={variants} className="relative">
     {children}
   </motion.div>

--- a/components/portfolio-card/DetailedAbout.tsx
+++ b/components/portfolio-card/DetailedAbout.tsx
@@ -4,6 +4,19 @@ import React from "react";
 import { motion } from "framer-motion";
 import { useTranslation } from "./useTranslation";
 
+interface Experience {
+  title: string;
+  company: string;
+  period: string;
+  description: string;
+}
+
+interface Education {
+  degree: string;
+  school: string;
+  year: string;
+}
+
 const fadeIn = (direction: string, type: string, delay: number, duration: number) => {
   const getX = () => {
     if (direction === "left") return 100;
@@ -69,7 +82,7 @@ const DetailedAbout = () => {
             {/* Expérience */}
             <section>
               <h3 className="text-primary font-semibold mb-3">{t.labels.experience}</h3>
-              {t.personalInfo.experience.map((exp: any) => (
+              {t.personalInfo.experience.map((exp: Experience) => (
                 <div key={exp.title} className="mb-4">
                   <h4 className="font-medium text-primary">{exp.title}</h4>
                   <p className="text-sm text-content">{exp.company} • {exp.period}</p>
@@ -81,7 +94,7 @@ const DetailedAbout = () => {
             {/* Éducation */}
             <section>
               <h3 className="text-primary font-semibold mb-3">{t.labels.education}</h3>
-              {t.personalInfo.education.map((edu: any) => (
+              {t.personalInfo.education.map((edu: Education) => (
                 <div key={edu.degree} className="mb-3">
                   <h4 className="font-medium text-primary">{edu.degree}</h4>
                   <p className="text-sm text-content">{edu.school} • {edu.year}</p>

--- a/components/portfolio-card/Projects.tsx
+++ b/components/portfolio-card/Projects.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import React from "react";
-import { motion } from "framer-motion";
+import {
+  motion,
+  type Variants,
+  type HTMLMotionProps,
+} from "framer-motion";
 import { useTranslation } from "./useTranslation";
 import Link from "next/link";
 
@@ -48,11 +52,28 @@ const staggerContainer = (staggerChildren?: number, delayChildren?: number) => (
   },
 });
 
-export const ContainerSlideIn = ({ children, variants, ...props }: any) => (
+interface ContainerSlideInProps extends HTMLMotionProps<"div"> {
+  children: React.ReactNode;
+  variants?: Variants;
+}
+
+export const ContainerSlideIn = ({
+  children,
+  variants,
+  ...props
+}: ContainerSlideInProps) => (
   <motion.div {...props} variants={variants} className="relative">
     {children}
   </motion.div>
 );
+
+interface Project {
+  name: string;
+  projects: string;
+  year: string;
+  url: string;
+  web: string;
+}
 
 const Projects = () => {
   const { t } = useTranslation();
@@ -102,7 +123,7 @@ const Projects = () => {
         whileInView="show"
         viewport={{ once: false, amount: 0.25 }}
       >
-        {t.projects.map((exp: any, i: number) => (
+        {t.projects.map((exp: Project, i: number) => (
           <ContainerSlideIn
             key={exp.name}
             variants={fadeIn("left", "tween", (i + 1) * 0.2, 0.8)}


### PR DESCRIPTION
## Summary
- define Experience and Education interfaces in `DetailedAbout` and use them in mappings
- type `ContainerSlideIn` wrappers and project entries to remove `any` usage

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inconsolata` and `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68affcf48d948325b228b1aa8b1e2080