### PR TITLE
chore: tighten project typings

### DIFF
--- a/components/portfolio-card/Projects.tsx
+++ b/components/portfolio-card/Projects.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import React from "react";
-import { motion } from "framer-motion";
+import { motion, Variants, HTMLMotionProps } from "framer-motion";
 import { useTranslation } from "./useTranslation";
 import Link from "next/link";
 
-const fadeIn = (direction: string, type: string, delay: number, duration: number) => {
+const fadeIn = (direction: string, type: string, delay: number, duration: number): Variants => {
   const getX = () => {
     if (direction === "left") return 100;
     if (direction === "right") return -100;
@@ -38,7 +38,7 @@ const fadeIn = (direction: string, type: string, delay: number, duration: number
   };
 };
 
-const staggerContainer = (staggerChildren?: number, delayChildren?: number) => ({
+const staggerContainer = (staggerChildren?: number, delayChildren?: number): Variants => ({
   hidden: {},
   show: {
     transition: {
@@ -48,11 +48,24 @@ const staggerContainer = (staggerChildren?: number, delayChildren?: number) => (
   },
 });
 
-export const ContainerSlideIn = ({ children, variants, ...props }: any) => (
+interface ContainerSlideInProps extends HTMLMotionProps<"div"> {
+  children: React.ReactNode;
+  variants: Variants;
+}
+
+export const ContainerSlideIn = ({ children, variants, ...props }: ContainerSlideInProps) => (
   <motion.div {...props} variants={variants} className="relative">
     {children}
   </motion.div>
 );
+
+interface Project {
+  name: string;
+  projects: string;
+  year: string;
+  url: string;
+  web: string;
+}
 
 const Projects = () => {
   const { t } = useTranslation();
@@ -102,7 +115,7 @@ const Projects = () => {
         whileInView="show"
         viewport={{ once: false, amount: 0.25 }}
       >
-        {t.projects.map((exp: any, i: number) => (
+        {t.projects.map((exp: Project, i: number) => (
           <ContainerSlideIn
             key={exp.name}
             variants={fadeIn("left", "tween", (i + 1) * 0.2, 0.8)}


### PR DESCRIPTION
## Summary
- define typed ContainerSlideInProps instead of any
- add Project interface for translation entries
- apply explicit types when mapping projects

## Testing
- `npm run lint` *(fails: Unexpected any in existing files)*
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68affcf6a8a48325890a5f8dfcbf9a30